### PR TITLE
Auto reload .orc files

### DIFF
--- a/Libraries/CsoundCMake/Core/Source/instrument_cc.orc
+++ b/Libraries/CsoundCMake/Core/Source/instrument_cc.orc
@@ -44,9 +44,17 @@ ${CSOUND_DEFINE} CC_SYNC_TO_CHANNEL #1#
 #define InitializeCcValuesInstrument CONCAT(INSTRUMENT_NAME, _InitializeCcValues)
 #define CreateCcIndexesInstrument CONCAT(INSTRUMENT_NAME, _CreateCcIndexes)
 
-
-giCcCount = (lenarray(gSCcInfo) / 4) - 1
-reshapearray(gSCcInfo, giCcCount + 1, 4)
+${CSOUND_IFDEF} CONCAT(CONCAT(gSCcInfo_, INSTRUMENT_NAME), _Count)
+    // Reshape the gSCcInfo array if it hasn't been reshaped already. This check is required for reloadable instruments
+    // because global arrays retain their shape across reloads.
+    if (lenarray(gSCcInfo) == CONCAT($, CONCAT(CONCAT(gSCcInfo_, INSTRUMENT_NAME), _Count))) then
+        giCcCount = (lenarray(gSCcInfo) / 4) - 1
+        reshapearray(gSCcInfo, giCcCount + 1, 4)
+    endif
+${CSOUND_ELSE}
+    giCcCount = (lenarray(gSCcInfo) / 4) - 1
+    reshapearray(gSCcInfo, giCcCount + 1, 4)
+${CSOUND_ENDIF}
 
 opcode ccIndex, i, S
     SChannel xin

--- a/Projects/.gitignore
+++ b/Projects/.gitignore
@@ -1,2 +1,3 @@
 **/bounce
 **/build
+**/node_modules

--- a/Projects/ProofOfConcept/.npmrc
+++ b/Projects/ProofOfConcept/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/Projects/ProofOfConcept/Csound/Synths/PointSynth.csd
+++ b/Projects/ProofOfConcept/Csound/Synths/PointSynth.csd
@@ -24,8 +24,13 @@ ${CSOUND_INCLUDE} "cabbage_synth_global.orc"
 ${CSOUND_INCLUDE} "TrackInfo_global.orc"
 ${CSOUND_INCLUDE} "time.orc"
 
+gkReloaded init false
 
 instr CompileOrc
+    if (gkReloaded == true) then
+        gkReloaded = false
+        turnoff
+    endif
     log_i_info("Compiling PointSynth.orc ...")
     iResult = compileorc("${CSD_PREPROCESSED_FILES_DIR}/PointSynth.orc")
     if (iResult == 0) then
@@ -33,6 +38,7 @@ instr CompileOrc
     else
         log_i_info("Compiling PointSynth.orc - failed")
     endif
+    gkReloaded = true
 endin
 
 

--- a/Projects/ProofOfConcept/Csound/Synths/PointSynth.orc
+++ b/Projects/ProofOfConcept/Csound/Synths/PointSynth.orc
@@ -52,6 +52,8 @@ instr PointSynth_Note
     iVelocity = p5 / 127
     iOrcInstanceIndex = p6
     iInstrumentTrackIndex = p7
+    aOut = poscil(0.01, cpsmidinn(iPitch))
+    outch(1, aOut)
 endin
 
 giPointSynthCcEventInstrumentNumber = nstrnum("PointSynth_CcEvent")
@@ -84,6 +86,11 @@ instr INSTRUMENT_ID
             outch(4, ao4)
             outch(5, ao5)
             outch(6, ao6)
+        
+            if (gkReloaded == true) then
+                log_k_debug("Turning off instrument %.03f due to reload.", p1)
+                turnoff
+            endif
         #endif
     endif
 endin

--- a/Projects/ProofOfConcept/Csound/Synths/PointSynth.orc
+++ b/Projects/ProofOfConcept/Csound/Synths/PointSynth.orc
@@ -20,6 +20,8 @@ _(\)
 _(\)
     "",                                         "",         "",                 "") // dummy line
 
+${CSOUND_DEFINE} CONCAT(CONCAT(gSCcInfo_, INSTRUMENT_NAME), _Count) #8#
+
 #include "instrument_cc.orc"
 
 instr CreateCcIndexesInstrument

--- a/Projects/ProofOfConcept/package.json
+++ b/Projects/ProofOfConcept/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "node-watch": "^0.7.1"
+  }
+}

--- a/Projects/ProofOfConcept/watch.js
+++ b/Projects/ProofOfConcept/watch.js
@@ -1,0 +1,42 @@
+var os = require('os');
+var watch = require('node-watch');
+var spawn = require('child_process').spawn;
+
+if (os.type() === 'Darwin') {
+    const foldersToWatch = [
+        './Csound',
+        '../../Libraries/CsoundCMake'
+    ]
+
+    let debounce = false
+    
+    const make = (event, fileName) => {
+        if (fileName) {
+            console.log('\n', fileName, 'changed ...')
+            if (debounce) {
+                return
+            }
+            debounce = setTimeout(() => {
+                debounce = false
+            }, 100) 
+            spawn('bash', [ '-c', 'node make'], { stdio: 'inherit' })
+        }
+    }
+
+    console.log('\nWatching folders ...')
+    foldersToWatch.forEach(folder => {
+        console.log('  ', folder)
+        watch(folder, {
+            recursive: true,
+            filter(path, skip) {
+                if (/\/build/.test(path)) {
+                    return skip
+                }
+                return true
+            }
+        }, make)
+    })
+}
+else {
+    throw new Error('Unsupported OS: ' + os.type())
+}


### PR DESCRIPTION
This change adds a `node watch` command to automatically run `node make` when files are changed on disk. This change also fixes the issues occurring when automatically reloading the PointSynth plugin's .orc file.