### PR TITLE
Move Python opcodes to DAW service

### DIFF
--- a/Libraries/CsoundCMake/Core/Source/definitions.h
+++ b/Libraries/CsoundCMake/Core/Source/definitions.h
@@ -45,10 +45,12 @@
 #define DAW_SERVICE_OSC_TRACK_REGISTRATION_PATH "/DawService/track/registration"
 #define DAW_SERVICE_OSC_TRACK_REFERENCING_PATH "/DawService/track/referencing"
 #define DAW_SERVICE_OSC_PLUGIN_REGISTRATION_PATH "/DawService/plugin/registration"
+#define DAW_SERVICE_OSC_PLUGIN_WATCH_ORC_PATH "/DawService/plugin/watch_orc"
 
 #define TRACK_INFO_OSC_ADDRESS "127.0.0.1"
 #define TRACK_INFO_OSC_PORT_MIN 7772
 #define TRACK_INFO_OSC_TRACK_SET_INDEX_PATH "/TrackInfo/track/set_index"
+#define TRACK_INFO_OSC_PLUGIN_ORC_CHANGED_PATH "/TrackInfo/plugin/orc_changed"
 
 #define TRACK_COUNT_MAX 1000
 #define PLUGIN_COUNT_MAX 100

--- a/Libraries/CsoundCMake/Core/Source/definitions.h
+++ b/Libraries/CsoundCMake/Core/Source/definitions.h
@@ -45,11 +45,13 @@
 #define DAW_SERVICE_OSC_TRACK_REGISTRATION_PATH "/DawService/track/registration"
 #define DAW_SERVICE_OSC_TRACK_REFERENCING_PATH "/DawService/track/referencing"
 #define DAW_SERVICE_OSC_PLUGIN_REGISTRATION_PATH "/DawService/plugin/registration"
+#define DAW_SERVICE_OSC_PLUGIN_REQUEST_UUID_PATH "/DawService/plugin/request_uuid"
 #define DAW_SERVICE_OSC_PLUGIN_WATCH_ORC_PATH "/DawService/plugin/watch_orc"
 
 #define TRACK_INFO_OSC_ADDRESS "127.0.0.1"
 #define TRACK_INFO_OSC_PORT_MIN 7772
 #define TRACK_INFO_OSC_TRACK_SET_INDEX_PATH "/TrackInfo/track/set_index"
+#define TRACK_INFO_OSC_PLUGIN_SET_UUID_PATH "/TrackInfo/plugin/set_uuid"
 #define TRACK_INFO_OSC_PLUGIN_ORC_CHANGED_PATH "/TrackInfo/plugin/orc_changed"
 
 #define TRACK_COUNT_MAX 1000

--- a/Projects/ProofOfConcept/Csound/Common/Common.cmake
+++ b/Projects/ProofOfConcept/Csound/Common/Common.cmake
@@ -1,0 +1,20 @@
+
+set(Project_Common_OrcFiles
+    "watchOrcFile.orc"
+    )
+
+foreach(orc_file ${Project_Common_OrcFiles})
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/${orc_file}" "${CSD_CONFIGURED_FILES_DIR}/${orc_file}")
+endforeach()
+
+if(NOT ${Build_InlineIncludes} EQUAL ON)
+    foreach(orc_file ${Project_Common_OrcFiles})
+        get_dependencies(orc_file_dependencies "${CSD_CONFIGURED_FILES_DIR}/${orc_file}")
+        add_preprocess_file_command(
+            "${CSD_CONFIGURED_FILES_DIR}/${orc_file}"
+            "${CSD_PREPROCESSED_FILES_DIR}/${orc_file}"
+            DEPENDS ${orc_file_dependencies}
+        )
+        list(APPEND CSD_DEPENDS "${CSD_PREPROCESSED_FILES_DIR}/${orc_file}")
+    endforeach()
+endif()

--- a/Projects/ProofOfConcept/Csound/DawService/DawService.csd
+++ b/Projects/ProofOfConcept/Csound/DawService/DawService.csd
@@ -18,6 +18,8 @@
 // Override core_global.h ksmps.
 kr = 1000
 
+pyinit
+
 // Turn off redundant OSC logging.
 #define DISABLE_LOGGING_TO_DAW_SERVICE
 
@@ -249,6 +251,15 @@ opcode addOrcInstance, 0, S
 endop
 
 
+opcode watchOrcFile, 0, SS
+    SPort, SOrcPath xin
+    iInstrumentNumber = nstrnum("WatchOrcFile")
+igoto end
+    scoreline(sprintfk("i%d 0 -1 %s \"%s\"", iInstrumentNumber, SPort, SOrcPath), 1)
+end:
+endop
+
+
 opcode set_mode, 0, k
     k_mode xin
     log_k_info("opcode set_mode(k_mode = %d) ...", k_mode)
@@ -439,6 +450,19 @@ instr HandleOscMessages
                 endif
 
 
+                // Plugin .orc change tracking
+                //
+                if (string_begins_with(S_oscPath, DAW_SERVICE_OSC_PLUGIN_WATCH_ORC_PATH) == true) then
+                    if (k_argCount < 2) then
+                        log_k_error("OSC path `%s` requires 2 arguments but was given %d.",
+                            DAW_SERVICE_OSC_PLUGIN_WATCH_ORC_PATH, k_argCount)
+                    else
+                        // 2 = port
+                        // 3 = .orc file path
+                        watchOrcFile(S_oscMessages[k(2)], S_oscMessages[k(3)])
+                    endif
+                endif
+
             endif
             k_j += 1
         od
@@ -530,6 +554,39 @@ instr RegisterPlugin
     log_i_trace("instr RegisterPlugin(i_trackIndex = %d, i_pluginIndex = %d, S_orcPath = %s, SUuid = %s) - done",
         i_trackIndex, i_pluginIndex, S_orcPath, SUuid)
     turnoff
+endin
+
+
+instr WatchOrcFile
+    iOscPort init p4
+    SOrcPath init strget(p5)
+
+    log_i_trace("instr WatchOrcFile(iOscPort = %d, SOrcPath = %s) ...", iOscPort, SOrcPath)
+
+    log_i_trace("  ... import os ...")
+    pylruni("import os")
+    log_i_trace("  ... import os - done")
+    SPythonCode = sprintf("float(os.path.getmtime(\"%s\"))", SOrcPath)
+
+    kPreviousTime init 0
+    kCurrentTime = time_k()
+    kPreviousModifiedTime init 0
+    kSignal init 1
+    if (kCurrentTime - kPreviousTime > 1) then
+        kPreviousTime = kCurrentTime
+        kModifiedTime = pyleval(SPythonCode)
+        if (kPreviousModifiedTime < kModifiedTime) then
+            if (kPreviousModifiedTime > 0) then
+                log_k_trace("%s changed", SOrcPath)
+                OSCsend(kSignal, TRACK_INFO_OSC_ADDRESS, iOscPort,
+                    sprintfk("%s/%d", TRACK_INFO_OSC_PLUGIN_ORC_CHANGED_PATH, iOscPort), "i", kSignal)
+                kSignal += 1
+            endif
+            kPreviousModifiedTime = kModifiedTime
+        endif
+    endif
+
+    log_i_trace("instr WatchOrcFile(iOscPort = %d, SOrcPath = %s) - done", iOscPort, SOrcPath)
 endin
 
 

--- a/Projects/ProofOfConcept/Csound/Synths/CircleSynth.cmake
+++ b/Projects/ProofOfConcept/Csound/Synths/CircleSynth.cmake
@@ -8,6 +8,7 @@ set(CSD_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CSD_SOURCE_FILE_PATH "${CSD_SOURCE_DIR}/${InstrumentName}.csd")
 get_generated_csd_dirs(CSD_CONFIGURED_FILES_DIR CSD_PREPROCESSED_FILES_DIR "${CSD_SOURCE_FILE_PATH}")
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/Common.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/S88.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/Tab.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/TrackInfo.cmake")

--- a/Projects/ProofOfConcept/Csound/Synths/CircleSynth.csd
+++ b/Projects/ProofOfConcept/Csound/Synths/CircleSynth.csd
@@ -21,55 +21,7 @@ ${CSOUND_DEFINE} PLUGIN_TRACK_TYPE #TRACK_TYPE_INSTRUMENT#
 ${CSOUND_INCLUDE} "cabbage_synth_global.orc"
 ${CSOUND_INCLUDE} "TrackInfo_global.orc"
 ${CSOUND_INCLUDE} "time.orc"
-
-gkReloaded init false
-
-
-instr CompileOrc
-    if (gkReloaded == true) then
-        gkReloaded = false
-        turnoff
-    endif
-
-    log_i_info("Compiling CircleSynth.orc ...")
-    iResult = compileorc("${CSD_PREPROCESSED_FILES_DIR}/CircleSynth.orc")
-    if (iResult == 0) then
-        log_i_info("Compiling CircleSynth.orc - succeeded")
-    else
-        log_i_info("Compiling CircleSynth.orc - failed")
-    endif
-    gkReloaded = true
-endin
-
-
-instr ListenForChangedOrcFile
-    log_i_trace("instr ListenForChangedOrcFile ...")
-
-    kSignal init -1
-    kReceived = OSClisten(gi_oscHandle, sprintf("%s/%d", TRACK_INFO_OSC_PLUGIN_ORC_CHANGED_PATH, gi_oscPort), "i",
-        kSignal)
-    if (kReceived == true) then
-        event("i", "CompileOrc", 0, -1)
-    endif
-
-    log_i_trace("instr ListenForChangedOrcFile - done")
-endin
-
-
-instr WatchOrcFile
-    log_i_trace("instr WatchOrcFile ...")
-    if (gi_oscHandle == -1) then
-        event("i", p1, 1, -1)
-    else
-        OSCsend(1, DAW_SERVICE_OSC_ADDRESS, DAW_SERVICE_OSC_PORT, DAW_SERVICE_OSC_PLUGIN_WATCH_ORC_PATH, "is",
-            gi_oscPort, "${CSD_PREPROCESSED_FILES_DIR}/CircleSynth.orc")
-        event("i", "ListenForChangedOrcFile", 0, -1)
-    endif
-    turnoff
-    log_i_trace("instr WatchOrcFile - done")
-endin
-
-alwayson "WatchOrcFile"
+${CSOUND_INCLUDE} "watchOrcFile.orc"
 
 
 //======================================================================================================================

--- a/Projects/ProofOfConcept/Csound/Synths/PointSynth.cmake
+++ b/Projects/ProofOfConcept/Csound/Synths/PointSynth.cmake
@@ -8,6 +8,7 @@ set(CSD_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CSD_SOURCE_FILE_PATH "${CSD_SOURCE_DIR}/${InstrumentName}.csd")
 get_generated_csd_dirs(CSD_CONFIGURED_FILES_DIR CSD_PREPROCESSED_FILES_DIR "${CSD_SOURCE_FILE_PATH}")
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/Common.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/S88.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/Tab.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/TrackInfo.cmake")

--- a/Projects/ProofOfConcept/Csound/Synths/PointSynth.csd
+++ b/Projects/ProofOfConcept/Csound/Synths/PointSynth.csd
@@ -8,8 +8,6 @@
 </CsOptions>
 <CsInstruments>
 
-pyinit
-
 #define OUT_CHANNEL_COUNT 6
 
 #include "cabbage_synth_global.h"
@@ -23,24 +21,7 @@ ${CSOUND_DEFINE} PLUGIN_TRACK_TYPE #TRACK_TYPE_INSTRUMENT#
 ${CSOUND_INCLUDE} "cabbage_synth_global.orc"
 ${CSOUND_INCLUDE} "TrackInfo_global.orc"
 ${CSOUND_INCLUDE} "time.orc"
-
-gkReloaded init false
-
-instr CompileOrc
-    if (gkReloaded == true) then
-        gkReloaded = false
-        turnoff
-    endif
-
-    log_i_info("Compiling PointSynth.orc ...")
-    iResult = compileorc("${CSD_PREPROCESSED_FILES_DIR}/PointSynth.orc")
-    if (iResult == 0) then
-        log_i_info("Compiling PointSynth.orc - succeeded")
-    else
-        log_i_info("Compiling PointSynth.orc - failed")
-    endif
-    gkReloaded = true
-endin
+${CSOUND_INCLUDE} "watchOrcFile.orc"
 
 
 //======================================================================================================================
@@ -50,20 +31,6 @@ endin
 instr 1
     ${CSOUND_INCLUDE} "cabbage_core_instr_1_head.orc"
     ${CSOUND_INCLUDE} "TrackInfo_instr_1_head.orc"
-
-    pylruni("import os")
-
-    kPreviousTime init 0
-    kCurrentTime = time_k()
-    kPreviousModifiedTime init 0
-    if (kCurrentTime - kPreviousTime > 1) then
-        kPreviousTime = kCurrentTime
-        kModifiedTime = pyleval("float(os.path.getmtime(\"${CSD_PREPROCESSED_FILES_DIR}/PointSynth.orc\"))")
-        if (kPreviousModifiedTime < kModifiedTime) then
-            kPreviousModifiedTime = kModifiedTime
-            event("i", "CompileOrc", 0, -1)
-        endif
-    endif
 endin
 
 

--- a/Projects/ProofOfConcept/Csound/Synths/PowerLineSynth.cmake
+++ b/Projects/ProofOfConcept/Csound/Synths/PowerLineSynth.cmake
@@ -8,6 +8,7 @@ set(CSD_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CSD_SOURCE_FILE_PATH "${CSD_SOURCE_DIR}/${InstrumentName}.csd")
 get_generated_csd_dirs(CSD_CONFIGURED_FILES_DIR CSD_PREPROCESSED_FILES_DIR "${CSD_SOURCE_FILE_PATH}")
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/Common.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/S88.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/Tab.cmake")
 include("${CsoundCMake.Cabbage_DIR}/Source/ui/TrackInfo.cmake")

--- a/Projects/ProofOfConcept/Csound/Synths/PowerLineSynth.csd
+++ b/Projects/ProofOfConcept/Csound/Synths/PowerLineSynth.csd
@@ -8,8 +8,6 @@
 </CsOptions>
 <CsInstruments>
 
-pyinit
-
 #define OUT_CHANNEL_COUNT 6
 
 #include "cabbage_synth_global.h"
@@ -23,24 +21,7 @@ ${CSOUND_DEFINE} PLUGIN_TRACK_TYPE #TRACK_TYPE_INSTRUMENT#
 ${CSOUND_INCLUDE} "cabbage_synth_global.orc"
 ${CSOUND_INCLUDE} "TrackInfo_global.orc"
 ${CSOUND_INCLUDE} "time.orc"
-
-gkReloaded init false
-
-instr CompileOrc
-    if (gkReloaded == true) then
-        gkReloaded = false
-        turnoff
-    endif
-
-    log_i_info("Compiling PowerLineSynth.orc ...")
-    iResult = compileorc("${CSD_PREPROCESSED_FILES_DIR}/PowerLineSynth.orc")
-    if (iResult == 0) then
-        log_i_info("Compiling PowerLineSynth.orc - succeeded")
-    else
-        log_i_info("Compiling PowerLineSynth.orc - failed")
-    endif
-    gkReloaded = true
-endin
+${CSOUND_INCLUDE} "watchOrcFile.orc"
 
 
 //======================================================================================================================
@@ -50,20 +31,6 @@ endin
 instr 1
     ${CSOUND_INCLUDE} "cabbage_core_instr_1_head.orc"
     ${CSOUND_INCLUDE} "TrackInfo_instr_1_head.orc"
-
-    pylruni("import os")
-
-    kPreviousTime init 0
-    kCurrentTime = time_k()
-    kPreviousModifiedTime init 0
-    if (kCurrentTime - kPreviousTime > 1) then
-        kPreviousTime = kCurrentTime
-        kModifiedTime = pyleval("float(os.path.getmtime(\"${CSD_PREPROCESSED_FILES_DIR}/PowerLineSynth.orc\"))")
-        if (kPreviousModifiedTime < kModifiedTime) then
-            kPreviousModifiedTime = kModifiedTime
-            event("i", "CompileOrc", 0, -1)
-        endif
-    endif
 endin
 
 


### PR DESCRIPTION
Using the Csound Python opcodes in plugins makes the DAW crash, probably because when multiple plugins try using the underlying Python system at the same time, they aren't doing it in a thread-safe way. This change fixes the issue by moving all usage of the Csound Python opcodes to the DAW service and exposing OSC APIs on the DAW service for the plugins to use for watching changes to .orc files and generating UUIDs instead of using the Csound Python opcodes directly.